### PR TITLE
[fix] missing parentheses in _max_point

### DIFF
--- a/algo/rrt_base.py
+++ b/algo/rrt_base.py
@@ -97,8 +97,8 @@ class RRTStarBase:
         if euclid_dist <= self._max_distance:
             return p2, False
 
-        new_x = p1.x + (p2.x - p1.x * self._max_distance / euclid_dist)
-        new_y = p1.y + (p2.y - p1.y * self._max_distance / euclid_dist)
+        new_x = p1.x + ((p2.x - p1.x) * self._max_distance / euclid_dist)
+        new_y = p1.y + ((p2.y - p1.y) * self._max_distance / euclid_dist)
         new_z = p1.z
         p_new = PointHeading((new_x, new_z, new_y))  # MAY RETURN non navigable point
 


### PR DESCRIPTION
Fix #1
- In algo/rrt_base.py, method _max_point(self, p1, p2) (lines 100, 101), there’s an error due to missing parentheses.